### PR TITLE
Add environment-friendly job filter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Search and Ad.
 ---
 
 Below is a simple example, more examples can be found in the `examples/` folder.
+For a demonstration of filtering for environment-friendly jobs with pay ranges
+see `examples/example_environment_jobs.py`.
 
 ```python
 import craigslistscraper as cs

--- a/examples/example_environment_jobs.py
+++ b/examples/example_environment_jobs.py
@@ -1,0 +1,64 @@
+import craigslistscraper as cs
+import re
+
+ENV_KEYWORDS = [
+    "environment",
+    "sustain",
+    "sustainable",
+    "green",
+    "renewable",
+    "climate",
+    "eco",
+    "environmental",
+]
+
+MIN_PAY = 3000
+MAX_PAY = 12500
+
+
+def contains_environment_keywords(text: str) -> bool:
+    lower = text.lower()
+    return any(keyword in lower for keyword in ENV_KEYWORDS)
+
+
+def parse_pay(text: str):
+    match = re.search(r"\$([\d,]+)(?:\s*[-to]+\s*\$([\d,]+))?", text)
+    if match:
+        amount = match.group(1)
+        return float(amount.replace(",", ""))
+    return None
+
+
+def filter_environment_ads(ads):
+    good = []
+    for ad in ads:
+        status = ad.fetch()
+        if status != 200:
+            continue
+        text = f"{ad.title or ''} {ad.description or ''}"
+        if not contains_environment_keywords(text):
+            continue
+        pay = parse_pay(text)
+        if pay is None or not (MIN_PAY <= pay <= MAX_PAY):
+            continue
+        good.append({
+            "title": ad.title,
+            "url": ad.url,
+            "pay": pay,
+        })
+    return good
+
+
+if __name__ == "__main__":
+    search = cs.Search(
+        query="environment",
+        city="seattle",
+        category="sof",
+    )
+    status = search.fetch()
+    if status != 200:
+        raise SystemExit(f"Unable to fetch search with status <{status}>")
+    env_ads = filter_environment_ads(search.ads)
+    print(f"{len(env_ads)} environment-friendly ads found!")
+    for ad in env_ads:
+        print(ad)


### PR DESCRIPTION
## Summary
- add example_environment_jobs.py showing how to filter jobs based on pay range and environmental keywords
- reference this new example in README

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6847ca0ba65c83239843f54a27adc818